### PR TITLE
add function which treats any character after '^g' as arguments

### DIFF
--- a/aliases/gitaliases
+++ b/aliases/gitaliases
@@ -7,7 +7,7 @@
 
 # add vim and emacs tempfiles to gitignore
 ignore() {
-    touch .gitignore 
+    touch .gitignore
     echo "*.sw*\n*#\ntags\n*~\n" | cat >> .gitignore
     git add .gitignore
     git commit -am "gitignore ignores vim and emacs tempfiles"
@@ -147,6 +147,18 @@ alias gllo="git llo"
 alias glllo="git lllo"
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+# this function lets you call your git aliases without explicitly defining an
+# alias for each one of them, eg. gco triggers automatically 'g co' etc.
+# http://superuser.com/a/756845/322005
+command_not_found_handle() {
+    case $1 in
+    # ffd*) find . -type d -iname "*${1#ffd}*"
+        # return 0
+        # ;;
+    g*) git ${1#g} "${@:2}"
+        return 0
+        ;;
+esac
 
 #gitinfo
 	alias gi=gitinfo


### PR DESCRIPTION
A few weeks ago I think you posted a comment on stackoverflow, explaining your way of treatening git aliases, which I found really clean and timesaving. So I adopted most of them to my own gitconfig. Anyhow I realised, every time I changed an alias, I had to define a new alias in my bashrc as well, which I thought was kind of annoying. So I asked at superuser.com and look what they responded :) Seems to be working quite nice so far. Hope you enjoy it as much as I do!

PS: I left in some outcommented lines (ffd), so you get an idea at the first glance.
PPS: forgot to mention, this function won't affect other commands such as `gnote, gimp ...` since it returns to bash's default if no other arguments defined.
